### PR TITLE
Fix for wrong dependendency while converting yaml to excel

### DIFF
--- a/src/main/java/de/arago/marstranslator/XlxsToMarsTranslator/NodeAttributes.java
+++ b/src/main/java/de/arago/marstranslator/XlxsToMarsTranslator/NodeAttributes.java
@@ -9,7 +9,7 @@ public class NodeAttributes
   public static String nodeID = "ID";
   public static String nodeName = "NodeName";
   public static String dependencies = "Dependencies";
-  public static String sourceCiID = "sourceCiId";
+  public static String sourceCiID = "SourceCiId";
   
 
   public static String hostname = "FQDN";

--- a/src/main/java/de/arago/marstranslator/XlxsToMarsTranslator/YAMLToJsonMapper.java
+++ b/src/main/java/de/arago/marstranslator/XlxsToMarsTranslator/YAMLToJsonMapper.java
@@ -99,7 +99,7 @@ public class YAMLToJsonMapper {
 
 	private void addDependency(int i, Map<Integer, String> variableContentMap,
 			String line) {
-		String[] content = line.split(" UID: "); 
+		String[] content = line.split("      ID: "); 
 		if(content.length > 1){
 			variableContentMap.put(i, content[1]);
 		}

--- a/src/main/java/de/arago/marstranslator/XlxsToMarsTranslator/YAMLToJsonMapper.java
+++ b/src/main/java/de/arago/marstranslator/XlxsToMarsTranslator/YAMLToJsonMapper.java
@@ -99,7 +99,7 @@ public class YAMLToJsonMapper {
 
 	private void addDependency(int i, Map<Integer, String> variableContentMap,
 			String line) {
-		String[] content = line.split("      ID: "); 
+		String[] content = line.split("      ID: ");
 		if(content.length > 1){
 			variableContentMap.put(i, content[1]);
 		}
@@ -129,7 +129,7 @@ public class YAMLToJsonMapper {
 
 
 	private boolean isDependency(String line) {
-		return line.startsWith("    UID");
+		return line.startsWith("      ID");
 	}
 
 	private String addHeaderLines(JSONObject jOut, String line) {


### PR DESCRIPTION
While converting the yaml dump files to excel, dependency column picks up the dependent block UID instead of node ids( ID).


